### PR TITLE
[Fix #138140325] matching secret santa odd scenario

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -91,13 +91,20 @@ class ShuffleView(APIView):
                 data = []
                 for pair in all_pairs:
                     # write each to the secretsanta model (msg queue perhaps?)
-                    if pair[1] is None:
-                        pair[1] = 1
-                    secretsanta = {
-                        "date": str(datetime.datetime.now().date()),
-                        "santa": pair[0],
-                        "giftee": pair[1]
-                    }
+                    if pair[1] is not None:
+                        secretsanta = {
+                            "date": str(datetime.datetime.now().date()),
+                            "santa": pair[0],
+                            "giftee": pair[1]
+                        }
+                    else:
+                        # In the event of a pending/ unpaired user
+                        # Default to admin user as the giftee
+                        secretsanta = {
+                            "date": str(datetime.datetime.now().date()),
+                            "santa": pair[0],
+                            "giftee": 1
+                        }
                     data.append(secretsanta)
 
                 serializer = SecretSantaSerializer(data=data, many=True)
@@ -113,7 +120,7 @@ class ShuffleView(APIView):
                     status=status.HTTP_400_BAD_REQUEST)
         except KeyError:
             return Response(
-                "Bad Request: Missing Key 'type'",
+                "Bad Request: Missing Either 'type' or 'limit' ",
                 status=status.HTTP_400_BAD_REQUEST)
 
 


### PR DESCRIPTION
#### What does this PR do?
It's a hot fix for matching secret santa pairs when the user count is odd

#### Description
If the user count is odd, one user will miss a pairing. Therefore, that user defaults to be paired by the super user (admin) whose pk is 1.
#### How should this be manually tested?
Fire up the server. Ensure you create an odd number of users first (eg. 3). Then, access 
http://localhost:8000/api/shuffle/ and send this json payload on a POST request:
```
{ 
   "type": "secretsanta",
   "limit": 2
}
```
You should see two serialized objects, each having (santa, giftee) pairs on them. 

#### Relevant pivotal tracker stories
#### Questions