### PR TITLE
Return next inline brownbags as a list

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -288,15 +288,8 @@ class BrownbagNextInLineView(generics.ListAPIView):
     """This view  queries for the next in line brownbag presenter."""
     serializer_class = BrownbagSerializer
 
-    def get(self, *args, **kwargs):
-        """
-        Return the brownbag entry as determined by status portion of the URL.
-        """
-        result = Brownbag.objects.filter(
-            status="next_in_line").latest('status')
-        serializer = BrownbagSerializer(result)
-
-        return Response(serializer.data, status=status.HTTP_200_OK)
+    def get_queryset(self):
+        return Brownbag.objects.filter(status="next_in_line")
 
 
 class SecretSantaView(generics.ListCreateAPIView):


### PR DESCRIPTION
#### What does this PR do?
Returns a a list of `next_in_line` brownbags, rather than a single brownbag.

#### Description of task to be completed?
 - Return next in line brownbags as a list

#### How should this be manually tested?
 - Hit the endpoint `GET api/brownbags/next/`
 - You should get the result as a list of brownbags