### PR TITLE
Add script to get users from slack using emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,17 @@ A Django-powered API for handling shufflebox consumption client requests
     SECRET_KEY=<Your-Secret-Key>
     DB_USER=<Your-username>
     DB_PASSWORD=<Your-password>
+    JWT_TOKEN=<YOUR JWT TOKEN>
+    DJANGO_SETTINGS_MODULE=<Path to settings file e.g core.settings.production>
+    USER_API_TOKEN=<Bearer token>
     USER_SERVICE_URL=<url-for-andela-user-microservice>
-    FILTER_PARAMS='<filter-to-query-users-from-microservice>'
+    FILTER_PARAMS=<filter-to-query-users-from-microservice>
+    EMAIL_USE_TLS=<EMAIL TLS>
+    EMAIL_HOST=<EMAIL HOST>
+    EMAIL_PORT=<EMAIL PORT>
+    EMAIL_HOST_USER=<EMAIL USER ADRESS>
+    EMAIL_HOST_PASSWORD=<EMAIL USER PASSWORD>
+    DEFAULT_FROM_EMAIL=<DEFAULT FROM EMAIL ADDRESS> e.g SHUFFLEBOX <shuffle@andela.com>
     ```
 
     Save the file. You'll need it to keep sensitive info from the outside world, and make migrations work! 😄

--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ A Django-powered API for handling shufflebox consumption client requests
     SECRET_KEY=<Your-Secret-Key>
     DB_USER=<Your-username>
     DB_PASSWORD=<Your-password>
+    JWT_TOKEN=<YOUR JWT TOKEN>
+    DJANGO_SETTINGS_MODULE=<Path to settings file e.g core.settings.production>
+    USER_API_TOKEN=<Bearer token>
+    USER_SERVICE_URL=<ANDELA USERS URL>
+    FILTER_PARAMS=<Filter params for the users to pull>
+    EMAIL_USE_TLS=<EMAIL TLS>
+    EMAIL_HOST=<EMAIL HOST>
+    EMAIL_PORT=<EMAIL PORT>
+    EMAIL_HOST_USER=<EMAIL USER ADRESS>
+    EMAIL_HOST_PASSWORD=<EMAIL USER PASSWORD>
+    DEFAULT_FROM_EMAIL=<DEFAULT FROM EMAIL ADDRESS> e.g SHUFFLEBOX <shuffle@andela.com>
     ```
 
     Save the file. You'll need it to keep sensitive info from the outside world, and make migrations work! 😄

--- a/api/management/commands/load_users.py
+++ b/api/management/commands/load_users.py
@@ -11,12 +11,12 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         headers = {
-            "Authorization": config("USER_API_TOKEN"),
+            "Authorization": config("USER_API_TOKEN", default=''),
             "Content-Type": "Application/json"
         }
         response = requests.get(
-            "{}?{}".format(config("USER_SERVICE_URL"),
-                           config("FILTER_PARAMS")),
+            "{}?{}".format(config("USER_SERVICE_URL", default=''),
+                           config("FILTER_PARAMS", default='')),
             headers=headers)
         if response.status_code == 200:
             # Loop though the users and add them to the db

--- a/api/management/commands/load_users.py
+++ b/api/management/commands/load_users.py
@@ -1,5 +1,6 @@
 import os
 import requests
+from decouple import config
 from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand
 
@@ -10,12 +11,12 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         headers = {
-            "Authorization": os.getenv("USER_API_TOKEN"),
+            "Authorization": config("USER_API_TOKEN"),
             "Content-Type": "Application/json"
         }
         response = requests.get(
-            "{}?{}".format(os.getenv("USER_SERVICE_URL"),
-                           os.getenv("FILTER_PARAMS")),
+            "{}?{}".format(config("USER_SERVICE_URL"),
+                           config("FILTER_PARAMS")),
             headers=headers)
         if response.status_code == 200:
             # Loop though the users and add them to the db

--- a/api/management/commands/load_users.py
+++ b/api/management/commands/load_users.py
@@ -1,4 +1,3 @@
-import os
 import requests
 from decouple import config
 from django.contrib.auth.models import User
@@ -25,7 +24,7 @@ class Command(BaseCommand):
             for person in persons:
                 try:
                     user = User.objects.create_user(
-                        username=person["email"],
+                        username='',
                         first_name=person["first_name"],
                         last_name=person["last_name"],
                         email=person["email"]

--- a/api/management/commands/load_users_from_slack.py
+++ b/api/management/commands/load_users_from_slack.py
@@ -1,0 +1,114 @@
+import csv
+import requests
+from api.utils import get_slack_user_object, notify_admin
+from decouple import config
+from django.contrib.auth.models import User
+from django.core.management.base import BaseCommand, CommandError
+from django.db import IntegrityError
+
+class Command(BaseCommand):
+    help = "Fetches users from slack and loads them to shufflebox"
+
+    def add_arguments(self, parser):
+        # parser.add_argument('file', nargs='+', type=str)
+        # parser.add_argument('email', nargs='+', type=str)
+        parser.add_argument(
+            '--file',
+            dest='file',
+            nargs='+',
+            type=str,
+            help='CSV file(s) containing a list of emails. DO NOT USE COMMAS TO SEPARATE THE DIFFERENT FILES e.g --file file1 file2'
+        )
+
+        parser.add_argument(
+            '--email',
+            dest='email',
+            nargs='+',
+            type=str,
+            help='User(s) email with no slack accounts. DO NOT USE COMMAS TO SEPARATE THE DIFFERENT EMAILS e.g --email email1 email2'
+        )
+
+    def handle(self, *args, **options):
+        try:
+            if options['file']:
+                # Fetch user objects based on their emails
+                response = requests.get(
+                    'https://slack.com/api/users.list?token={}'.format(
+                        config('SLACK_TOKEN', default='')))
+                if response.status_code == 200 and response.json()['ok'] == True:
+                    # List of users objects
+                    members = response.json()['members']
+                    count = 0
+                    unmatched_emails = ''
+                    for csv_file in options['file']:
+                        with open(csv_file, 'r') as file:
+                            emails = csv.reader(file)
+                            for email in emails:
+                                email = email[0]
+                                if User.objects.filter(email=email):
+                                    continue
+                                user_obj = get_slack_user_object(email, members)
+                                co_email = email.replace('com', 'co')
+                                co_user_obj = get_slack_user_object(co_email, members)
+                                if user_obj:
+                                    user = User.objects.create_user(
+                                        username=user_obj['name'],
+                                        first_name=user_obj['profile'].get('first_name', ''),
+                                        last_name=user_obj['profile'].get('last_name', ''),
+                                        email=email
+                                    )
+                                    user.profile.avatar = user_obj['profile']['image_{}'.format(24)]
+                                    user.profile.bio = user_obj['profile'].get('title','')
+                                    user.save()
+                                    count += 1
+                                elif co_user_obj:
+                                    user = User.objects.create_user(
+                                        username=co_user_obj['name'],
+                                        first_name=co_user_obj['profile'].get('first_name', ''),
+                                        last_name=co_user_obj['profile'].get('last_name', ''),
+                                        email=email
+                                    )
+                                    user.profile.avatar = co_user_obj['profile']['image_{}'.format(24)]
+                                    user.profile.bio = co_user_obj['profile'].get('title', '')
+                                    user.save()
+                                    count += 1
+                                else:
+                                    unmatched_emails = unmatched_emails + email + '\r'
+                    if unmatched_emails:
+                        message = "The following users don't have slack accounts\r{}".format(unmatched_emails)
+                        notify_admin('Users without slack', message)
+                    if count > 0:
+                        self.stdout.write(
+                            self.style.SUCCESS('Successfully added {} users to shufflebox via email'.format(count)))
+                    else:
+                        self.stdout.write(self.style.SUCCESS('No users added to shufflebox'))
+                else:
+                    if response.status_code == 200:
+                        self.stderr.write("Slack Error: {}. Check token".format(response.json()['error']))
+                    else:
+                        self.stderr.write("Response Error: {}".format(response.status_code))
+            elif options['email']:
+                count = 0
+                for email in options['email']:
+                    if User.objects.filter(email=email):
+                        continue
+                    user = User.objects.create_user(
+                        username=email.split('@')[0],
+                        first_name=email.split('.')[0],
+                        last_name=email.split('.')[1].split('@')[0],
+                        email=email
+                    )
+                    user.profile.avatar = ''
+                    user.profile.bio = ''
+                    user.save()
+                    count += 1
+                if count > 0:
+                    self.stdout.write(self.style.SUCCESS('Successfully added {} users to shufflebox via email'.format(count)))
+                else:
+                    self.stdout.write(self.style.SUCCESS('No users added to shufflebox'))
+            else:
+                self.stderr.write('No options specifed. Use ./manage.py load_users_from_slack --help to check available options')
+        except IntegrityError:
+            pass  # user already exists
+        except Exception as e:
+            raise CommandError(str(e))

--- a/api/tests/test_custom_auth.py
+++ b/api/tests/test_custom_auth.py
@@ -5,7 +5,7 @@ from rest_framework import status
 import os
 
 
-AUTH_TOKEN = config('JWT_TOKEN')
+AUTH_TOKEN = config('JWT_TOKEN', default='')
 AUTH_HEADER = 'JWT ' + AUTH_TOKEN
 
 

--- a/api/tests/test_custom_auth.py
+++ b/api/tests/test_custom_auth.py
@@ -1,10 +1,11 @@
 from api.authentication import CustomTokenAuthentication
+from decouple import config
 from rest_framework.test import APITestCase
 from rest_framework import status
 import os
 
 
-AUTH_TOKEN = os.getenv('JWT_TOKEN')
+AUTH_TOKEN = config('JWT_TOKEN')
 AUTH_HEADER = 'JWT ' + AUTH_TOKEN
 
 

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -1,3 +1,4 @@
+from decouple import config
 from django.test import TestCase
 from rest_framework.test import APIClient
 from rest_framework import status
@@ -12,7 +13,7 @@ import os
 from api.serializers import UserSerializer
 
 
-AUTH_TOKEN = 'JWT ' + os.getenv('JWT_TOKEN')
+AUTH_TOKEN = 'JWT ' + config('JWT_TOKEN')
 
 
 class UserViewTestCase(TestCase):

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -13,7 +13,7 @@ import os
 from api.serializers import UserSerializer
 
 
-AUTH_TOKEN = 'JWT ' + config('JWT_TOKEN')
+AUTH_TOKEN = 'JWT ' + config('JWT_TOKEN', default='')
 
 
 class UserViewTestCase(TestCase):

--- a/api/utils.py
+++ b/api/utils.py
@@ -67,3 +67,11 @@ def notify_admin(subject, message):
         mail_admins(subject=subject, message=message, fail_silently=False)
     except SMTPException as e:
         return str(e)
+
+def get_slack_user_object(email, members):
+    for user in members:
+        try:
+            if email == user.get('profile').get('email'):
+                return user
+        except KeyError:
+            return False

--- a/api/views.py
+++ b/api/views.py
@@ -130,7 +130,7 @@ class ShuffleView(APIView):
                     secret_santas.append(secretsanta_pair)
 
                 # Make P&C the Santa for those not picked
-                admin = User.objects.get(username="shufflebox@andela.com")
+                admin = User.objects.get(email="shufflebox@andela.com")
                 if remainder is not None:
                     secret_santas.append(
                         SecretSanta.objects.create(

--- a/api/views.py
+++ b/api/views.py
@@ -171,8 +171,8 @@ class SendMailView(APIView):
                     message = f.readlines()
                 message = ''.join(message)
                 for santa in santas:
-                    gifter = santa.santa.username
-                    giftee = santa.giftee.username
+                    gifter = santa.santa.email
+                    giftee = santa.giftee.email
                     if validate_address(gifter) and validate_address(giftee):
                         mail.create_message(message.format(giftee),[gifter])
                     else:

--- a/core/settings/__init__.py
+++ b/core/settings/__init__.py
@@ -6,7 +6,7 @@ from decouple import config
 from dotenv import load_dotenv
 
 # Ensure development settings are not used in testing and production:
-if not config('CI', default=False) and not config('HEROKU', default=False):
+if not config('CI', default=None) and not config('HEROKU', default=None):
     # load and set environment variables from '.env.yml' or '.env.py' files
     # with django_envie
 

--- a/core/settings/__init__.py
+++ b/core/settings/__init__.py
@@ -2,11 +2,11 @@
 Settings package initialization.
 """
 
-import os
+from decouple import config
 from dotenv import load_dotenv
 
 # Ensure development settings are not used in testing and production:
-if not os.getenv('CI') and not os.getenv('HEROKU'):
+if not config('CI', default=False) and not config('HEROKU', default=False):
     # load and set environment variables from '.env.yml' or '.env.py' files
     # with django_envie
 
@@ -14,8 +14,8 @@ if not os.getenv('CI') and not os.getenv('HEROKU'):
 
     from core.settings.development import *
 
-if os.getenv('HEROKU'):
+if config('HEROKU', default=False):
     from core.settings.production import *
 
-if os.getenv('TRAVIS_BUILD'):
+if config('TRAVIS_BUILD', default=False):
     from core.settings.test import *

--- a/core/settings/base.py
+++ b/core/settings/base.py
@@ -21,7 +21,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/1.10/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = config('SECRET_KEY')
+SECRET_KEY = config('SECRET_KEY', default=None)
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
@@ -172,8 +172,8 @@ ADMINS = [
 ]
 
 EMAIL_USE_TLS = config('EMAIL_USE_TLS', default=True, cast=bool)
-EMAIL_HOST = config('EMAIL_HOST')
-EMAIL_PORT = config('EMAIL_PORT', cast=int)
-EMAIL_HOST_USER = config('EMAIL_HOST_USER')
-EMAIL_HOST_PASSWORD = config('EMAIL_HOST_PASSWORD')
-DEFAULT_FROM_EMAIL = config('DEFAULT_FROM_EMAIL')
+EMAIL_HOST = config('EMAIL_HOST', default='')
+EMAIL_PORT = config('EMAIL_PORT' , default='', cast=int)
+EMAIL_HOST_USER = config('EMAIL_HOST_USER', default='')
+EMAIL_HOST_PASSWORD = config('EMAIL_HOST_PASSWORD', default='')
+DEFAULT_FROM_EMAIL = config('DEFAULT_FROM_EMAIL', default='')

--- a/core/settings/base.py
+++ b/core/settings/base.py
@@ -21,7 +21,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/1.10/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = config('SECRET_KEY')
+SECRET_KEY = config('SECRET_KEY', default=None)
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
@@ -172,8 +172,8 @@ ADMINS = [
 ]
 
 EMAIL_USE_TLS = config('EMAIL_USE_TLS', default=True, cast=bool)
-EMAIL_HOST = config('EMAIL_HOST')
-EMAIL_PORT = config('EMAIL_PORT', cast=int)
-EMAIL_HOST_USER = config('EMAIL_HOST_USER')
-EMAIL_HOST_PASSWORD = config('EMAIL_HOST_PASSWORD')
-DEFAULT_FROM_EMAIL = config('DEFAULT_FROM_EMAIL')
+EMAIL_HOST = config('EMAIL_HOST', default='')
+EMAIL_PORT = config('EMAIL_PORT' , default=None, cast=int)
+EMAIL_HOST_USER = config('EMAIL_HOST_USER', default='')
+EMAIL_HOST_PASSWORD = config('EMAIL_HOST_PASSWORD', default='')
+DEFAULT_FROM_EMAIL = config('DEFAULT_FROM_EMAIL', default='')

--- a/core/settings/base.py
+++ b/core/settings/base.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/1.10/ref/settings/
 """
 
 import os
+from decouple import config
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -20,7 +21,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/1.10/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.getenv('SECRET_KEY')
+SECRET_KEY = config('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
@@ -126,9 +127,9 @@ AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',
 )
 
-SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = os.getenv('GOOGLE_OAUTH2_KEY')
+SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = config('GOOGLE_OAUTH2_KEY', default='')
 
-SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = os.getenv('GOOGLE_OAUTH2_SECRET')
+SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = config('GOOGLE_OAUTH2_SECRET', default='')
 
 SOCIAL_AUTH_GOOGLE_OAUTH2_SCOPE = ['email', 'profile']
 
@@ -170,9 +171,9 @@ ADMINS = [
     ('Bonnie', 'boniface.mwenda@andela.com')
 ]
 
-EMAIL_USE_TLS = True
-EMAIL_HOST = 'smtp.gmail.com'
-EMAIL_PORT = 587
-EMAIL_HOST_USER = 'shufflebox@andela.com'
-EMAIL_HOST_PASSWORD = 'everydayamshuffling'
-DEFAULT_FROM_EMAIL = 'SHUFFLEBOX <shufflebox@andela.com>'
+EMAIL_USE_TLS = config('EMAIL_USE_TLS', default=True, cast=bool)
+EMAIL_HOST = config('EMAIL_HOST')
+EMAIL_PORT = config('EMAIL_PORT', cast=int)
+EMAIL_HOST_USER = config('EMAIL_HOST_USER')
+EMAIL_HOST_PASSWORD = config('EMAIL_HOST_PASSWORD')
+DEFAULT_FROM_EMAIL = config('DEFAULT_FROM_EMAIL')

--- a/core/settings/base.py
+++ b/core/settings/base.py
@@ -173,7 +173,7 @@ ADMINS = [
 
 EMAIL_USE_TLS = config('EMAIL_USE_TLS', default=True, cast=bool)
 EMAIL_HOST = config('EMAIL_HOST', default='')
-EMAIL_PORT = config('EMAIL_PORT' , default=None, cast=int)
+EMAIL_PORT = config('EMAIL_PORT' , default='', cast=int)
 EMAIL_HOST_USER = config('EMAIL_HOST_USER', default='')
 EMAIL_HOST_PASSWORD = config('EMAIL_HOST_PASSWORD', default='')
 DEFAULT_FROM_EMAIL = config('DEFAULT_FROM_EMAIL', default='')

--- a/core/settings/development.py
+++ b/core/settings/development.py
@@ -12,8 +12,8 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': 'core',
-        'USER': config('DB_USER'),
-        'PASSWORD': config('DB_PASSWORD'),
+        'USER': config('DB_USER', default=''),
+        'PASSWORD': config('DB_PASSWORD', default=''),
         'HOST': '127.0.0.1',
         'PORT': '5432'
     }

--- a/core/settings/development.py
+++ b/core/settings/development.py
@@ -3,6 +3,7 @@ Development specific settings.
 """
 
 from core.settings.base import *
+from decouple import config
 
 # Database
 # https://docs.djangoproject.com/en/1.8/ref/settings/#databases
@@ -11,8 +12,8 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': 'core',
-        'USER': os.getenv('DB_USER'),
-        'PASSWORD': os.getenv('DB_PASSWORD'),
+        'USER': config('DB_USER'),
+        'PASSWORD': config('DB_PASSWORD'),
         'HOST': '127.0.0.1',
         'PORT': '5432'
     }

--- a/core/settings/test.py
+++ b/core/settings/test.py
@@ -3,10 +3,11 @@ Test specific settings.
 """
 
 from core.settings.base import *
+from decouple import config
 
 #Use the following live settings to build on Travis CI
-if os.getenv('TRAVIS_BUILD', None):
-    SECRET_KEY = os.getenv('SECRET_KEY')
+if config('TRAVIS_BUILD', default=None):
+    SECRET_KEY = config('SECRET_KEY')
     DEBUG = False
 
     DATABASES = {

--- a/core/settings/test.py
+++ b/core/settings/test.py
@@ -7,7 +7,7 @@ from decouple import config
 
 #Use the following live settings to build on Travis CI
 if config('TRAVIS_BUILD', default=None):
-    SECRET_KEY = config('SECRET_KEY')
+    SECRET_KEY = config('SECRET_KEY', default=None)
     DEBUG = False
 
     DATABASES = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ Pygments==2.2.0
 PyJWT==1.4.2
 pypi-publisher==0.0.4
 python-dateutil==2.6.0
+python-decouple==3.1
 python-dotenv==0.6.2
 python-openid==2.2.5
 python3-openid==3.0.10
@@ -37,4 +38,3 @@ social-auth-app-django==1.0.1
 social-auth-core==1.1.0
 Sphinx==1.5.2
 sphinx-rtd-theme==0.1.9
-wheel==0.24.0


### PR DESCRIPTION
#### What does this PR do?
Adds a django command to allow users to be added from slack and not api using emails
#### Description of Task to be completed?
Find consistent data to be used by shufflebox
#### How should this be manually tested?
run `./manage.py load_users_from_slack --file path/to/emails.csv` to add from a csv file
or `./manage.py load_users_from_slack --email email` to add a user based on their email address
or `./manage.py load_users_from_slack --slack email` to add a user from slack using the correct email
#### Any background context you want to provide?
Andela's microservice was returning inconsistent data so we had to use data from slack as it was more consistent